### PR TITLE
 Refactor: Align cache path with Laravel conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ composer require elegantly/laravel-translator --dev
 Add the following line to your `.gitignore` file:
 
 ```
-.translator.cache
+storage/.translator.cache
 ```
 
 Publish the configuration file:

--- a/config/translator.php
+++ b/config/translator.php
@@ -151,7 +151,7 @@ return [
                  * To speed up detection, all the results of the scan will be stored in a file.
                  * Feel free to change the path if needed.
                  */
-                'cache_path' => base_path('.translator.cache'),
+                'cache_path' => storage_path('.translator.cache'),
             ],
         ],
 

--- a/src/Commands/ClearCacheCommand.php
+++ b/src/Commands/ClearCacheCommand.php
@@ -5,8 +5,6 @@ namespace Elegantly\Translator\Commands;
 use Elegantly\Translator\Facades\Translator;
 use Illuminate\Console\Command;
 
-use function Laravel\Prompts\info;
-
 class ClearCacheCommand extends Command
 {
     public $signature = 'translator:clear-cache';
@@ -17,7 +15,7 @@ class ClearCacheCommand extends Command
     {
         Translator::clearCache();
 
-        info('Cache cleared');
+        $this->components->info('Translator cache cleared.');
 
         return self::SUCCESS;
     }

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -4,8 +4,9 @@ namespace Elegantly\Translator\Commands;
 
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 
+use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;
-use function Laravel\Prompts\progress;
+use function Laravel\Prompts\note;
 use function Laravel\Prompts\table;
 
 class MissingCommand extends TranslatorCommand implements PromptsForMissingInput
@@ -20,85 +21,41 @@ class MissingCommand extends TranslatorCommand implements PromptsForMissingInput
         $sync = (bool) $this->option('sync');
 
         $translator = $this->getTranslator();
+
         $missing = $translator->getMissingTranslations($locale);
 
-        intro('Using driver: ' . $translator->driver::class);
+        intro('Using driver: '.$translator->driver::class);
 
-        $missingCount = count($missing);
+        note(count($missing).' missing keys detected.');
 
-        if ($missingCount === 0) {
-            $this->components->info('No missing keys found for locale: ' . $locale);
-            return self::SUCCESS;
-        }
-
-        $this->components->info("{$missingCount} missing keys detected.");
-        $this->newLine();
-
-        if (!$sync) {
-            table(
-                headers: ['Key', 'Total Count', 'Files'],
-                rows: $this->formatMissingKeys($missing)
-            );
-        }
+        table(
+            headers: ['Key', 'Count', 'Files'],
+            rows: collect($missing)
+                ->map(function ($value, $key) {
+                    return [
+                        str($key)->limit(20)->value(),
+                        (string) $value['count'],
+                        implode("\n",
+                            array_map(
+                                fn ($file) => str($file)->after(base_path()),
+                                $value['files'],
+                            )
+                        ),
+                    ];
+                })->values()->all()
+        );
 
         if ($sync) {
-            $this->syncMissingKeysWithProgress($translator, $locale, $missing);
+
+            $translator->setTranslations(
+                locale: $locale,
+                values: array_map(fn () => null, $missing)
+            );
+
+            info(count($missing).' missing keys added to the driver.');
+
         }
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Format missing keys for display in the table.
-     *
-     * @param array $missing
-     * @return array
-     */
-    private function formatMissingKeys(array $missing): array
-    {
-        return collect($missing)
-            ->map(fn($value, $key) => [
-                str($key)->limit(20)->value(),
-                (string) $value['count'],
-                implode("\n", $this->formatFiles($value['files'])),
-            ])
-            ->values()
-            ->all();
-    }
-
-    /**
-     * Format file paths for display.
-     *
-     * @param array $files
-     * @return array
-     */
-    private function formatFiles(array $files): array
-    {
-        return array_map(
-            fn($file) => str($file)->after(base_path())->value(),
-            $files
-        );
-    }
-
-    /**
-     * Sync missing keys with the translator driver, showing a progress bar.
-     *
-     * @param object $translator
-     * @param string $locale
-     * @param array $missing
-     * @return void
-     */
-    private function syncMissingKeysWithProgress($translator, string $locale, array $missing): void
-    {
-        $progress = progress(label: 'Syncing...', steps: count($missing));
-        $progress->start();
-
-        foreach ($missing as $key => $value) {
-            $translator->setTranslation($locale, $key, null);
-            $progress->advance();
-        }
-
-        $progress->finish();
-        $this->components->info(count($missing) . ' missing keys have been synced.');
     }
 }

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -4,7 +4,6 @@ namespace Elegantly\Translator\Commands;
 
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 
-use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\progress;
 use function Laravel\Prompts\table;
@@ -28,7 +27,7 @@ class MissingCommand extends TranslatorCommand implements PromptsForMissingInput
         $missingCount = count($missing);
 
         if ($missingCount === 0) {
-            info('No missing keys found for locale: ' . $locale);
+            $this->components->info('No missing keys found for locale: ' . $locale);
             return self::SUCCESS;
         }
 

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;
-use function Laravel\Prompts\note;
+use function Laravel\Prompts\progress;
 use function Laravel\Prompts\table;
 
 class MissingCommand extends TranslatorCommand implements PromptsForMissingInput
@@ -21,41 +21,85 @@ class MissingCommand extends TranslatorCommand implements PromptsForMissingInput
         $sync = (bool) $this->option('sync');
 
         $translator = $this->getTranslator();
-
         $missing = $translator->getMissingTranslations($locale);
 
-        intro('Using driver: '.$translator->driver::class);
+        intro('Using driver: ' . $translator->driver::class);
 
-        note(count($missing).' missing keys detected.');
+        $missingCount = count($missing);
 
-        table(
-            headers: ['Key', 'Count', 'Files'],
-            rows: collect($missing)
-                ->map(function ($value, $key) {
-                    return [
-                        str($key)->limit(20)->value(),
-                        (string) $value['count'],
-                        implode("\n",
-                            array_map(
-                                fn ($file) => str($file)->after(base_path()),
-                                $value['files'],
-                            )
-                        ),
-                    ];
-                })->values()->all()
-        );
+        if ($missingCount === 0) {
+            info('No missing keys found for locale: ' . $locale);
+            return self::SUCCESS;
+        }
+
+        $this->components->info("{$missingCount} missing keys detected.");
+        $this->newLine();
+
+        if (!$sync) {
+            table(
+                headers: ['Key', 'Total Count', 'Files'],
+                rows: $this->formatMissingKeys($missing)
+            );
+        }
 
         if ($sync) {
-
-            $translator->setTranslations(
-                locale: $locale,
-                values: array_map(fn () => null, $missing)
-            );
-
-            info(count($missing).' missing keys added to the driver.');
-
+            $this->syncMissingKeysWithProgress($translator, $locale, $missing);
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Format missing keys for display in the table.
+     *
+     * @param array $missing
+     * @return array
+     */
+    private function formatMissingKeys(array $missing): array
+    {
+        return collect($missing)
+            ->map(fn($value, $key) => [
+                str($key)->limit(20)->value(),
+                (string) $value['count'],
+                implode("\n", $this->formatFiles($value['files'])),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Format file paths for display.
+     *
+     * @param array $files
+     * @return array
+     */
+    private function formatFiles(array $files): array
+    {
+        return array_map(
+            fn($file) => str($file)->after(base_path())->value(),
+            $files
+        );
+    }
+
+    /**
+     * Sync missing keys with the translator driver, showing a progress bar.
+     *
+     * @param object $translator
+     * @param string $locale
+     * @param array $missing
+     * @return void
+     */
+    private function syncMissingKeysWithProgress($translator, string $locale, array $missing): void
+    {
+        $progress = progress(label: 'Syncing...', steps: count($missing));
+        $progress->start();
+
+        foreach ($missing as $key => $value) {
+            $translator->setTranslation($locale, $key, null);
+            $progress->advance();
+        }
+
+        $progress->finish();
+        $this->components->info(count($missing) . ' missing keys have been synced.');
     }
 }


### PR DESCRIPTION
Hey @QuentinGab,

I made a few things. Review this and if any changes are needed, you can change it.

- I moved the default cache path to the `storage` folder for better alignment with Laravel conventions.
- Added progress bar and improved messages