### PR TITLE
Fix locale logged when adding new locale

### DIFF
--- a/src/Commands/AddLocaleCommand.php
+++ b/src/Commands/AddLocaleCommand.php
@@ -48,7 +48,7 @@ class AddLocaleCommand extends TranslatorCommand implements PromptsForMissingInp
             $translations->map(fn () => null)
         );
 
-        info("{$source} added with {$count} keys.");
+        info("{$locale} added with {$count} keys.");
 
         if ($translate) {
             $translated = spin(function () use ($translator, $source, $locale, $translations) {


### PR DESCRIPTION
The command to add a new locale has params `$locale` and `$source`, the `info()` log command used to say that the `$source` was added, when actually the `$locale` was added.