### PR TITLE
Refactoring PhpTranslations for performance

### DIFF
--- a/src/Collections/JsonTranslations.php
+++ b/src/Collections/JsonTranslations.php
@@ -8,9 +8,6 @@ use Elegantly\Translator\Drivers\JsonDriver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
-/**
- * @extends Translations<null|scalar>
- */
 class JsonTranslations extends Translations
 {
     public string $driver = JsonDriver::class;
@@ -20,9 +17,6 @@ class JsonTranslations extends Translations
         return array_key_exists($key, $this->items);
     }
 
-    /**
-     * @return null|scalar
-     */
     public function get(string $key): mixed
     {
         return $this->items[$key] ?? null;
@@ -30,7 +24,8 @@ class JsonTranslations extends Translations
 
     public function dot(): Collection
     {
-        return $this->collect();
+        // @phpstan-ignore-next-line
+        return new Collection($this->items);
     }
 
     public static function undot(Collection|array $items): static
@@ -76,11 +71,16 @@ class JsonTranslations extends Translations
 
     public function filter(?callable $callback = null): static
     {
-        return new static(array_filter(
-            $this->items,
-            $callback,
-            ARRAY_FILTER_USE_BOTH
-        ));
+        if ($callback) {
+            return new static(array_filter(
+                $this->items,
+                $callback,
+                ARRAY_FILTER_USE_BOTH
+            ));
+        }
+
+        return new static(array_filter($this->items));
+
     }
 
     public function map(?callable $callback = null): static
@@ -91,5 +91,14 @@ class JsonTranslations extends Translations
                 $callback
             )
         );
+    }
+
+    public function sortKeys(int $options = SORT_REGULAR, bool $descending = false): static
+    {
+        $items = $this->items;
+
+        $descending ? krsort($items, $options) : ksort($items, $options);
+
+        return new static($items);
     }
 }

--- a/src/Collections/JsonTranslations.php
+++ b/src/Collections/JsonTranslations.php
@@ -22,6 +22,15 @@ class JsonTranslations extends Translations
         return $this->items[$key] ?? null;
     }
 
+    public function set(string $key, null|int|float|string|bool $value): static
+    {
+        $items = $this->items;
+
+        $items[$key] = $value;
+
+        return new static($items);
+    }
+
     public function dot(): Collection
     {
         // @phpstan-ignore-next-line
@@ -49,8 +58,10 @@ class JsonTranslations extends Translations
         );
     }
 
-    public function merge(array $values): static
+    public function merge(Translations|array $values): static
     {
+        $values = $values instanceof Translations ? $values->dot()->all() : $values;
+
         return new static(
             array_merge(
                 $this->items,

--- a/src/Collections/JsonTranslations.php
+++ b/src/Collections/JsonTranslations.php
@@ -5,10 +5,91 @@ declare(strict_types=1);
 namespace Elegantly\Translator\Collections;
 
 use Elegantly\Translator\Drivers\JsonDriver;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
+/**
+ * @extends Translations<null|scalar>
+ */
 class JsonTranslations extends Translations
 {
     public string $driver = JsonDriver::class;
 
-    //
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->items);
+    }
+
+    /**
+     * @return null|scalar
+     */
+    public function get(string $key): mixed
+    {
+        return $this->items[$key] ?? null;
+    }
+
+    public function dot(): Collection
+    {
+        return $this->collect();
+    }
+
+    public static function undot(Collection|array $items): static
+    {
+        $items = $items instanceof Collection ? $items->all() : $items;
+
+        return new static($items);
+    }
+
+    public function only(array $keys): static
+    {
+        return new static(
+            array_intersect_key($this->items, array_flip((array) $keys))
+        );
+    }
+
+    public function except(array $keys): static
+    {
+        return new static(
+            array_diff_key($this->items, array_flip((array) $keys))
+        );
+    }
+
+    public function merge(array $values): static
+    {
+        return new static(
+            array_merge(
+                $this->items,
+                $values
+            )
+        );
+    }
+
+    public function diff(Translations $translations): static
+    {
+        return new static(
+            array_diff_key(
+                $this->items,
+                $translations->all()
+            )
+        );
+    }
+
+    public function filter(?callable $callback = null): static
+    {
+        return new static(array_filter(
+            $this->items,
+            $callback,
+            ARRAY_FILTER_USE_BOTH
+        ));
+    }
+
+    public function map(?callable $callback = null): static
+    {
+        return new static(
+            Arr::map(
+                $this->items,
+                $callback
+            )
+        );
+    }
 }

--- a/src/Collections/PhpTranslations.php
+++ b/src/Collections/PhpTranslations.php
@@ -16,7 +16,7 @@ class PhpTranslations extends Translations
     {
         return new Collection(
             Arr::dot(
-                static::prepareTranslations($this->items)
+                static::prepareTranslations($this->items) ?? []
             )
         );
     }

--- a/src/Collections/PhpTranslations.php
+++ b/src/Collections/PhpTranslations.php
@@ -42,6 +42,15 @@ class PhpTranslations extends Translations
         return Arr::has($this->items, $key);
     }
 
+    public function set(string $key, null|int|float|string|bool $value): static
+    {
+        $items = $this->items;
+
+        Arr::set($items, $key, $value);
+
+        return new static($items);
+    }
+
     public function only(array $keys): static
     {
         $items = [];
@@ -176,14 +185,17 @@ class PhpTranslations extends Translations
         );
     }
 
-    public function merge(array $values): static
+    public function merge(Translations|array $values): static
     {
-        return new static(
-            array_merge_recursive(
-                $this->items,
-                $values
-            )
-        );
+        $values = $values instanceof Translations ? $values->dot()->all() : $values;
+
+        $items = new static($this->items);
+
+        foreach ($values as $key => $value) {
+            $items = $items->set($key, $value);
+        }
+
+        return $items;
     }
 
     public function diff(Translations $translations): static

--- a/src/Collections/PhpTranslations.php
+++ b/src/Collections/PhpTranslations.php
@@ -6,190 +6,186 @@ namespace Elegantly\Translator\Collections;
 
 use Elegantly\Translator\Drivers\PhpDriver;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Enumerable;
-use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 
+/**
+ * @extends Translations<null|scalar|array<array-key, mixed>>
+ */
 class PhpTranslations extends Translations
 {
     public string $driver = PhpDriver::class;
 
-    /**
-     * Should then mimic the laravel __ method
-     *
-     * ! $this->items are dotted !
-     *
-     * $items = ['foo.bar' => 'baz']
-     * - $this->get('foo.bar') === 'baz'
-     * - $this->get('foo') === [ 'bar' => 'baz']
-     * - $this->get('bar') === null
-     */
-    public function get($key, $default = null)
+    public function dot(): Collection
     {
-        $values = [];
-
-        foreach ($this->items as $translationKey => $translationValue) {
-            if ($key === $translationKey) {
-                return $translationValue;
-            }
-
-            if (Str::startsWith($translationKey, $key)) {
-                $values[$translationKey] = $translationValue;
-            }
-        }
-
-        if (! empty($values)) {
-            return Arr::get(
-                Arr::undot($values),
-                $key
-            );
-        }
-
-        // @phpstan-ignore-next-line
-        return $default;
-    }
-
-    /**
-     * Should mimic the laravel __ method
-     *
-     * - 'auth.user.email' === 'auth.user.email' // true
-     * - 'auth.user.email' === 'auth.user' // true
-     * - 'auth.user.email' === 'auth.user.email.label' // false
-     * - 'auth.user.email' === 'auth.admin' // false
-     */
-    public static function isSubTranslationKey(
-        int|string $translationKey,
-        int|string $key
-    ): bool {
-        if ($translationKey === $key) {
-            return true;
-        }
-
-        return Str::startsWith((string) $translationKey, "{$key}.");
-    }
-
-    /**
-     * @param  array<array-key, mixed>  $translations
-     */
-    public static function hasTranslationKey(
-        array $translations,
-        int|string $key
-    ): bool {
-
-        foreach ($translations as $translationKey => $translationValue) {
-            if (static::isSubTranslationKey($translationKey, $key)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Should mimic the laravel __ method
-     *
-     * $items = ['foo.bar' => 'baz']
-     * - $this->has('foo.bar') === true
-     * - $this->has('foo') === true
-     * - $this->has('bar') === false
-     */
-    public function has($key)
-    {
-        /** @var array<int, array-key> */
-        $keys = Arr::wrap($key);
-
-        foreach ($keys as $value) {
-            if (! static::hasTranslationKey(
-                translations: $this->items,
-                key: $value
-            )) {
-                return false;
-            }
-        }
-
-        return true;
-
-    }
-
-    /**
-     * Should mimic the laravel __ method
-     * $items = ['foo.bar' => 'baz']
-     * - $this->except('foo.bar') === []
-     * - $this->except('foo') === []
-     * - $this->except('bar') === $items
-     */
-    public function except($keys)
-    {
-
-        if ($keys instanceof Enumerable) {
-            $keys = $keys->all();
-        } elseif (! is_array($keys)) {
-            $keys = func_get_args();
-        }
-
-        /** @var array<array-key, array-key> $keys */
-        return $this->filter(function ($translationValue, $translationKey) use ($keys) {
-
-            foreach ($keys as $key) {
-                if (static::isSubTranslationKey($translationKey, $key)) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
-    }
-
-    /**
-     * Should mimic the laravel __ method
-     * $items = ['foo.bar' => 'baz']
-     * - $this->only('foo.bar') === $items
-     * - $this->only('foo') === $items
-     * - $this->only('bar') === []
-     */
-    public function only($keys)
-    {
-        if (is_null($keys)) {
-            return new static($this->items);
-        }
-
-        if ($keys instanceof Enumerable) {
-            $keys = $keys->all();
-        }
-
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        /** @var array<array-key, array-key> $keys */
-        return $this->filter(function ($translationValue, $translationKey) use ($keys) {
-
-            foreach ($keys as $key) {
-                if (static::isSubTranslationKey($translationKey, $key)) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
-    }
-
-    /**
-     * @param  array<array-key, mixed>  $values
-     */
-    public static function toDot(array $values): static
-    {
-        return new static(
-            Arr::dot(static::prepareTranslations($values) ?? [])
+        return new Collection(
+            Arr::dot(
+                static::prepareTranslations($this->items)
+            )
         );
     }
 
-    /**
-     * @param  Translations|array<array-key, mixed>  $translations
-     * @return array<array-key, mixed> $values
-     */
-    public static function toUndot(Translations|array $translations): array
+    public static function undot(Collection|array $items): static
     {
-        $translations = $translations instanceof Translations ? $translations->all() : $translations;
+        $items = $items instanceof Collection ? $items->all() : $items;
 
-        return static::unprepareTranslations(Arr::undot($translations)) ?? [];
+        return new static(
+            static::unprepareTranslations(
+                Arr::undot($items)
+            ) ?? []
+        );
+    }
+
+    public function get(string $key): mixed
+    {
+        return Arr::get($this->items, $key);
+    }
+
+    public function has(string $key): bool
+    {
+        return Arr::has($this->items, $key);
+    }
+
+    public function only(array $keys): static
+    {
+        $items = [];
+
+        foreach ($keys as $key) {
+
+            if ($this->has($key)) {
+                Arr::set(
+                    $items,
+                    $key,
+                    $this->get($key)
+                );
+            }
+        }
+
+        return new static($items);
+    }
+
+    /**
+     * @param  array<array-key, null|scalar|array<array-key, mixed>>  $items
+     * @param  string[]  $segments
+     */
+    protected function recursiveForget(array &$items, array $segments): void
+    {
+        $segment = array_shift($segments);
+
+        if (! array_key_exists($segment, $items)) {
+            return;
+        }
+
+        if (empty($segments)) {
+            unset($items[$segment]);
+        } elseif (is_array($items[$segment])) {
+            $this->recursiveForget($items[$segment], $segments);
+
+            if (empty($items[$segment])) {
+                unset($items[$segment]);
+            }
+        }
+
+    }
+
+    public function except(array $keys): static
+    {
+        $items = $this->items;
+
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $items)) {
+                unset($items[$key]);
+            } elseif (str_contains($key, '.')) {
+
+                $this->recursiveForget(
+                    $items,
+                    explode('.', $key)
+                );
+
+            }
+        }
+
+        return new static($items);
+    }
+
+    /**
+     * @param  array<array-key, null|scalar|array<array-key, mixed>>  $items
+     * @return array<array-key, null|scalar|array<array-key, mixed>>
+     */
+    protected function recursiveFilter(array $items, callable $callback): array
+    {
+        /**
+         * @var array<array-key, null|scalar|array<array-key, mixed>>
+         */
+        $result = [];
+
+        foreach ($items as $key => $value) {
+            if (is_array($value)) {
+                if ($subresult = $this->recursiveFilter($value, $callback)) {
+                    $result[$key] = $subresult;
+                }
+            } elseif ($callback($value, $key)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    public function filter(?callable $callback = null): static
+    {
+        return new static($this->recursiveFilter(
+            $this->items,
+            $callback
+        ));
+    }
+
+    /**
+     * @param  array<array-key, null|scalar|array<array-key, mixed>>  $items
+     * @return array<array-key, null|scalar|array<array-key, mixed>>
+     */
+    protected function recursiveMap(array $items, callable $callback): array
+    {
+        /**
+         * @var array<array-key, null|scalar|array<array-key, mixed>>
+         */
+        $result = [];
+
+        foreach ($items as $key => $value) {
+            if (is_array($value)) {
+                $result[$key] = $this->recursiveMap($value, $callback);
+            } else {
+                $result[$key] = $callback($value, $key);
+            }
+        }
+
+        return $result;
+    }
+
+    public function map(?callable $callback = null): static
+    {
+        return new static(
+            $this->recursiveMap(
+                $this->items,
+                $callback
+            )
+        );
+    }
+
+    public function merge(array $values): static
+    {
+        return new static(
+            array_merge_recursive(
+                $this->items,
+                $values
+            )
+        );
+    }
+
+    public function diff(Translations $translations): static
+    {
+        return $this->except(
+            $translations->dot()->keys()->all()
+        );
     }
 
     /**
@@ -198,8 +194,9 @@ class PhpTranslations extends Translations
      */
     public static function prepareTranslations(mixed $values, bool $escape = false): mixed
     {
+
         if ($escape && is_string($values)) {
-            return Str::replace('.', '&#46;', $values);
+            return str_replace('.', '&#46;', $values);
         }
 
         if (! is_array($values)) {
@@ -210,11 +207,12 @@ class PhpTranslations extends Translations
             return null;
         }
 
-        return collect($values)
-            ->mapWithKeys(fn ($value, $key) => [
+        return Arr::mapWithKeys(
+            $values,
+            fn ($value, $key) => [
                 static::prepareTranslations($key, true) => static::prepareTranslations($value),
-            ])
-            ->all();
+            ]
+        );
     }
 
     /**
@@ -224,7 +222,7 @@ class PhpTranslations extends Translations
     public static function unprepareTranslations(mixed $values, bool $unescape = false): mixed
     {
         if ($unescape && is_string($values)) {
-            return Str::replace('&#46;', '.', $values);
+            return str_replace('&#46;', '.', $values);
         }
 
         if (! is_array($values)) {
@@ -235,10 +233,11 @@ class PhpTranslations extends Translations
             return null;
         }
 
-        return collect($values)
-            ->mapWithKeys(fn ($value, $key) => [
+        return Arr::mapWithKeys(
+            $values,
+            fn ($value, $key) => [
                 static::unprepareTranslations($key, true) => static::unprepareTranslations($value),
-            ])
-            ->all();
+            ]
+        );
     }
 }

--- a/src/Collections/Translations.php
+++ b/src/Collections/Translations.php
@@ -51,6 +51,8 @@ abstract class Translations implements Arrayable, Countable, Jsonable
         return (string) $value;
     }
 
+    abstract public function set(string $key, null|int|float|string|bool $value): static;
+
     /**
      * @return Collection<array-key, null|scalar>
      */
@@ -72,9 +74,9 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     abstract public function except(array $keys): static;
 
     /**
-     * @param  array<array-key, null|scalar|array<array-key, mixed>>  $values
+     * @param  Translations|array<array-key, null|scalar>  $values
      */
-    abstract public function merge(array $values): static;
+    abstract public function merge(Translations|array $values): static;
 
     abstract public function diff(Translations $translations): static;
 

--- a/src/Collections/Translations.php
+++ b/src/Collections/Translations.php
@@ -11,9 +11,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 
 /**
- * @template TValue
- *
- * @implements Arrayable<string, TValue>
+ * @implements Arrayable<string, null|scalar|array<array-key, mixed>>
  */
 abstract class Translations implements Arrayable, Countable, Jsonable
 {
@@ -23,12 +21,12 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     public string $driver;
 
     /**
-     * @var array<array-key, TValue>
+     * @var array<array-key, null|scalar|array<array-key, mixed>>
      */
     public array $items = [];
 
     /**
-     * @param  array<array-key, TValue>|Collection<array-key,TValue>  $items
+     * @param  array<array-key, null|scalar|array<array-key, mixed>>|Collection<array-key,null|scalar|array<array-key, mixed>>  $items
      */
     final public function __construct(array|Collection $items = [])
     {
@@ -38,9 +36,20 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     abstract public function has(string $key): bool;
 
     /**
-     * @return TValue
+     * @return null|scalar|array<array-key, mixed>
      */
     abstract public function get(string $key): mixed;
+
+    public function getString(string $key): string
+    {
+        $value = $this->get($key);
+
+        if (is_array($value)) {
+            return '';
+        }
+
+        return (string) $value;
+    }
 
     /**
      * @return Collection<array-key, null|scalar>
@@ -48,7 +57,7 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     abstract public function dot(): Collection;
 
     /**
-     * @param  Collection<array-key, TValue>|array<array-key, TValue>  $items
+     * @param  Collection<array-key, null|scalar|array<array-key, mixed>>|array<array-key, null|scalar|array<array-key, mixed>>  $items
      */
     abstract public static function undot(Collection|array $items): static;
 
@@ -63,24 +72,23 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     abstract public function except(array $keys): static;
 
     /**
-     * @param  array<array-key, TValue>  $values
+     * @param  array<array-key, null|scalar|array<array-key, mixed>>  $values
      */
     abstract public function merge(array $values): static;
 
-    /**
-     * @param  Translations<TValue>  $translations
-     */
     abstract public function diff(Translations $translations): static;
 
     /**
-     * @param  null|(callable(array-key, TValue):mixed)  $callback
+     * @param  null|(callable(null|scalar|array<array-key, mixed>, array-key):mixed)  $callback
      */
     abstract public function filter(?callable $callback = null): static;
 
     /**
-     * @param  null|(callable(array-key, TValue):mixed)  $callback
+     * @param  null|(callable(null|scalar|array<array-key, mixed>, array-key):mixed)  $callback
      */
     abstract public function map(?callable $callback = null): static;
+
+    abstract public function sortKeys(int $options = SORT_REGULAR, bool $descending = false): static;
 
     public function notBlank(): static
     {
@@ -90,7 +98,7 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     }
 
     /**
-     * @return array<array-key, TValue>
+     * @return array<array-key, null|scalar|array<array-key, mixed>>
      */
     public function all(): array
     {
@@ -106,10 +114,11 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     }
 
     /**
-     * @return Collection<array-key, TValue>
+     * @return Collection<array-key, null|scalar|array<array-key, mixed>>
      */
     public function collect(): Collection
     {
+        // @phpstan-ignore-next-line
         return new Collection($this->items);
     }
 
@@ -120,6 +129,7 @@ abstract class Translations implements Arrayable, Countable, Jsonable
      */
     public function toBase(): Collection
     {
+        // @phpstan-ignore-next-line
         return $this->dot();
     }
 
@@ -129,7 +139,7 @@ abstract class Translations implements Arrayable, Countable, Jsonable
     }
 
     /**
-     * @return array<array-key, TValue>
+     * @return array<array-key, null|scalar|array<array-key, mixed>>
      */
     public function toArray(): array
     {

--- a/src/Collections/Translations.php
+++ b/src/Collections/Translations.php
@@ -4,28 +4,140 @@ declare(strict_types=1);
 
 namespace Elegantly\Translator\Collections;
 
+use Countable;
 use Elegantly\Translator\Drivers\Driver;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 
 /**
- * @extends Collection<string, scalar|null>
+ * @template TValue
+ *
+ * @implements Arrayable<string, TValue>
  */
-abstract class Translations extends Collection
+abstract class Translations implements Arrayable, Countable, Jsonable
 {
     /**
      * @var class-string<Driver>
      */
     public string $driver;
 
-    final public function __construct($items = [])
+    /**
+     * @var array<array-key, TValue>
+     */
+    public array $items = [];
+
+    /**
+     * @param  array<array-key, TValue>|Collection<array-key,TValue>  $items
+     */
+    final public function __construct(array|Collection $items = [])
     {
-        $this->items = parent::getArrayableItems($items);
+        $this->items = $items instanceof Collection ? $items->all() : $items;
     }
+
+    abstract public function has(string $key): bool;
+
+    /**
+     * @return TValue
+     */
+    abstract public function get(string $key): mixed;
+
+    /**
+     * @return Collection<array-key, null|scalar>
+     */
+    abstract public function dot(): Collection;
+
+    /**
+     * @param  Collection<array-key, TValue>|array<array-key, TValue>  $items
+     */
+    abstract public static function undot(Collection|array $items): static;
+
+    /**
+     * @param  array<int, array-key>  $keys
+     */
+    abstract public function only(array $keys): static;
+
+    /**
+     * @param  array<int, array-key>  $keys
+     */
+    abstract public function except(array $keys): static;
+
+    /**
+     * @param  array<array-key, TValue>  $values
+     */
+    abstract public function merge(array $values): static;
+
+    /**
+     * @param  Translations<TValue>  $translations
+     */
+    abstract public function diff(Translations $translations): static;
+
+    /**
+     * @param  null|(callable(array-key, TValue):mixed)  $callback
+     */
+    abstract public function filter(?callable $callback = null): static;
+
+    /**
+     * @param  null|(callable(array-key, TValue):mixed)  $callback
+     */
+    abstract public function map(?callable $callback = null): static;
 
     public function notBlank(): static
     {
-        return $this->filter(function ($value) {
-            return ! blank($value);
-        });
+        return $this->filter(
+            fn ($value) => ! blank($value)
+        );
+    }
+
+    /**
+     * @return array<array-key, TValue>
+     */
+    public function all(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @return array<int, array-key>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->items);
+    }
+
+    /**
+     * @return Collection<array-key, TValue>
+     */
+    public function collect(): Collection
+    {
+        return new Collection($this->items);
+    }
+
+    /**
+     * @deprecated Use `dot` method instead
+     *
+     * @return Collection<array-key, null|scalar>
+     */
+    public function toBase(): Collection
+    {
+        return $this->dot();
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * @return array<array-key, TValue>
+     */
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    public function toJson($options = 0): string
+    {
+        return json_encode($this->toArray(), $options) ?: '';
     }
 }

--- a/src/Commands/AddLocaleCommand.php
+++ b/src/Commands/AddLocaleCommand.php
@@ -68,7 +68,7 @@ class AddLocaleCommand extends TranslatorCommand implements PromptsForMissingInp
                     ->map(function ($value, $key) use ($translations) {
                         return [
                             (string) $key,
-                            (string) str((string) $translations->get($key))->limit(25),
+                            (string) str($translations->getString($key))->limit(25),
                             (string) str((string) $value)->limit(25),
                         ];
                     })->toArray()

--- a/src/Commands/AddLocaleCommand.php
+++ b/src/Commands/AddLocaleCommand.php
@@ -56,20 +56,22 @@ class AddLocaleCommand extends TranslatorCommand implements PromptsForMissingInp
                 return $translator->translateTranslations(
                     source: $source,
                     target: $locale,
-                    keys: $translations->keys()->toArray()
+                    keys: $translations->dot()->keys()->toArray()
                 );
 
             }, "Translating the {$count} missing translations from '{$source}' to '{$locale}'");
 
             table(
                 headers: ['Key', "Source {$source}", "Target {$locale}"],
-                rows: $translated->map(function ($value, $key) use ($translations) {
-                    return [
-                        (string) $key,
-                        (string) str((string) $translations[$key])->limit(25),
-                        (string) str((string) $value)->limit(25),
-                    ];
-                })->toArray()
+                rows: $translated
+                    ->dot()
+                    ->map(function ($value, $key) use ($translations) {
+                        return [
+                            (string) $key,
+                            (string) str((string) $translations->get($key))->limit(25),
+                            (string) str((string) $value)->limit(25),
+                        ];
+                    })->toArray()
             );
         }
 

--- a/src/Commands/DeadCommand.php
+++ b/src/Commands/DeadCommand.php
@@ -36,7 +36,7 @@ class DeadCommand extends TranslatorCommand implements PromptsForMissingInput
         table(
             headers: ['Key', "Translation {$locale}"],
             rows: $dead
-                ->toBase()
+                ->dot()
                 ->map(function ($value, $key) {
                     return [
                         $key,
@@ -51,7 +51,7 @@ class DeadCommand extends TranslatorCommand implements PromptsForMissingInput
 
             $translator->deleteTranslations(
                 locale: $locale,
-                keys: $dead->keys()->toArray()
+                keys: $dead->dot()->keys()->all()
             );
 
             note(count($dead).' dead translations deleted from the driver.');

--- a/src/Commands/ProofreadCommand.php
+++ b/src/Commands/ProofreadCommand.php
@@ -43,9 +43,9 @@ class ProofreadCommand extends TranslatorCommand implements PromptsForMissingInp
             rows: $translations
                 ->dot()
                 ->map(fn ($value, $key) => [
-                    $key,
+                    (string) $key,
                     (string) str((string) $value)->limit(25),
-                    (string) str((string) $proofread->get($key))->limit(25),
+                    (string) str($proofread->getString($key))->limit(25),
                 ])
                 ->all()
         );

--- a/src/Commands/ProofreadCommand.php
+++ b/src/Commands/ProofreadCommand.php
@@ -33,7 +33,7 @@ class ProofreadCommand extends TranslatorCommand implements PromptsForMissingInp
         $proofread = spin(
             fn () => $translator->proofreadTranslations(
                 locale: $locale,
-                keys: $translations->toBase()->keys()->all()
+                keys: $translations->dot()->keys()->all()
             ),
             'Proofreading the translation strings.'
         );
@@ -41,11 +41,13 @@ class ProofreadCommand extends TranslatorCommand implements PromptsForMissingInp
         table(
             headers: ['Key', 'Before', 'After'],
             rows: $translations
+                ->dot()
                 ->map(fn ($value, $key) => [
                     $key,
                     (string) str((string) $value)->limit(25),
                     (string) str((string) $proofread->get($key))->limit(25),
-                ])->toArray()
+                ])
+                ->all()
         );
 
         return self::SUCCESS;

--- a/src/Commands/SortCommand.php
+++ b/src/Commands/SortCommand.php
@@ -32,10 +32,12 @@ class SortCommand extends TranslatorCommand implements PromptsForMissingInput
         table(
             headers: ['Key', 'Translation'],
             rows: $tranlations
+                ->dot()
                 ->map(fn ($value, $key) => [
                     (string) $key,
                     (string) str((string) $value)->limit(50),
-                ])->toArray()
+                ])
+                ->all()
         );
 
         return self::SUCCESS;

--- a/src/Commands/UntranslatedCommand.php
+++ b/src/Commands/UntranslatedCommand.php
@@ -62,7 +62,7 @@ class UntranslatedCommand extends TranslatorCommand implements PromptsForMissing
                     ->map(function ($value, $key) use ($missing) {
                         return [
                             (string) $key,
-                            str((string) $missing->get($key))->limit(25)->value(),
+                            str($missing->getString($key))->limit(25)->value(),
                             str((string) $value)->limit(25)->value(),
                         ];
                     })

--- a/src/Commands/UntranslatedCommand.php
+++ b/src/Commands/UntranslatedCommand.php
@@ -37,6 +37,7 @@ class UntranslatedCommand extends TranslatorCommand implements PromptsForMissing
         table(
             headers: ['Key', "Source {$source}"],
             rows: $missing
+                ->dot()
                 ->map(fn ($value, $key) => [
                     $key,
                     (string) str((string) $value)->limit(50),
@@ -49,7 +50,7 @@ class UntranslatedCommand extends TranslatorCommand implements PromptsForMissing
                 return $translator->translateTranslations(
                     source: $source,
                     target: $target,
-                    keys: $missing->toBase()->keys()->all()
+                    keys: $missing->dot()->keys()->all()
                 );
 
             }, "Translating the {$count} translations from '{$source}' to '{$target}'");
@@ -57,11 +58,11 @@ class UntranslatedCommand extends TranslatorCommand implements PromptsForMissing
             table(
                 headers: ['Key', "Source {$source}", "Target {$target}"],
                 rows: $translated
-                    ->toBase()
+                    ->dot()
                     ->map(function ($value, $key) use ($missing) {
                         return [
-                            $key,
-                            str((string) $missing[$key])->limit(25)->value(),
+                            (string) $key,
+                            str((string) $missing->get($key))->limit(25)->value(),
                             str((string) $value)->limit(25)->value(),
                         ];
                     })

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -89,6 +89,12 @@ class JsonDriver extends Driver
         return new JsonTranslations;
     }
 
+    /**
+     * @template T of JsonTranslations
+     *
+     * @param  T  $translations
+     * @return T
+     */
     public function saveTranslations(string $locale, Translations $translations): Translations
     {
         $this->storage->put(
@@ -99,7 +105,7 @@ class JsonDriver extends Driver
         return $translations;
     }
 
-    public static function collect(): Translations
+    public static function collect(): JsonTranslations
     {
         return new JsonTranslations;
     }

--- a/src/Drivers/PhpDriver.php
+++ b/src/Drivers/PhpDriver.php
@@ -98,7 +98,9 @@ class PhpDriver extends Driver
             })
             ->all();
 
-        return PhpTranslations::toDot($values);
+        return new PhpTranslations(
+            PhpTranslations::prepareTranslations($values)
+        );
     }
 
     /**
@@ -128,11 +130,17 @@ class PhpDriver extends Driver
 
     }
 
+    /**
+     * @template T of Translations
+     *
+     * @param  T  $translations
+     * @return T
+     */
     public function saveTranslations(string $locale, Translations $translations): Translations
     {
-        $undot = PhpTranslations::toUndot($translations);
+        $items = PhpTranslations::unprepareTranslations($translations->toArray());
 
-        foreach ($undot as $namespace => $values) {
+        foreach ($items as $namespace => $values) {
 
             $this->storage->put(
                 $this->getFilePath($locale, $namespace),
@@ -209,7 +217,7 @@ class PhpDriver extends Driver
         return $output;
     }
 
-    public static function collect(): Translations
+    public static function collect(): PhpTranslations
     {
         return new PhpTranslations;
     }

--- a/src/Facades/Translator.php
+++ b/src/Facades/Translator.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array<int, string> getLocales()
  * @method static Translations getTranslations(string $locale)
  * @method static array<string, array{ count: int, files: string[] }> getMissingTranslations(string $locale)
- * @method static array<int, scalar|null> getDeadTranslations(string $locale)
+ * @method static Translations getDeadTranslations(string $locale)
  * @method static Translations getUntranslatedTranslations(string $source, string $target)
  * @method static Translations setTranslations(string $locale, array<string, scalar|null> $values)
  * @method static Translations translateTranslations(string $source, string $target, array<int, string> $keys)

--- a/src/Services/Exporter/CsvExporterService.php
+++ b/src/Services/Exporter/CsvExporterService.php
@@ -32,14 +32,21 @@ class CsvExporterService implements ExporterInterface
 
         /** @var string[] $keys */
         $keys = collect($translationsByLocale)
-            ->flatMap(fn ($translations) => $translations->keys())
+            ->flatMap(fn ($translations) => $translations->dot()->keys()->all())
             ->unique()
             ->all();
 
         foreach ($keys as $key) {
 
             $values = array_map(function ($locale) use ($translationsByLocale, $key) {
-                return $translationsByLocale[$locale][$key] ?? null;
+
+                $value = $translationsByLocale[$locale]->get($key);
+
+                if (is_array($value)) {
+                    return null;
+                }
+
+                return $value;
             }, $locales);
 
             $writer->addRow([

--- a/src/Services/Proofread/ProofreadServiceInterface.php
+++ b/src/Services/Proofread/ProofreadServiceInterface.php
@@ -7,8 +7,8 @@ namespace Elegantly\Translator\Services\Proofread;
 interface ProofreadServiceInterface
 {
     /**
-     * @param  array<string, string>  $texts
-     * @return array<string, string>
+     * @param  array<array-key, null|scalar>  $texts
+     * @return array<array-key, null|scalar>
      */
     public function proofreadAll(array $texts): array;
 

--- a/src/Services/Translate/TranslateServiceInterface.php
+++ b/src/Services/Translate/TranslateServiceInterface.php
@@ -7,8 +7,8 @@ namespace Elegantly\Translator\Services\Translate;
 interface TranslateServiceInterface
 {
     /**
-     * @param  array<string, string>  $texts
-     * @return array<string, string>
+     * @param  array<array-key, null|scalar>  $texts
+     * @return array<array-key, null|scalar>
      */
     public function translateAll(array $texts, string $targetLocale): array;
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -128,7 +128,7 @@ class Translator
             ->filter(function ($value, $key) use ($translations) {
                 return ! $translations->has($key);
             })
-            ->toArray();
+            ->all();
     }
 
     /**
@@ -155,10 +155,7 @@ class Translator
         $sourceTranslations = $this->getTranslations($source)->notBlank();
         $targetTranslations = $this->getTranslations($target)->notBlank();
 
-        return $sourceTranslations
-            ->filter(function ($value, $key) use ($targetTranslations) {
-                return ! $targetTranslations->has($key);
-            });
+        return $sourceTranslations->diff($targetTranslations);
     }
 
     /**

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -212,8 +212,9 @@ class Translator
 
                 $sourceTranslations = $this->getTranslations($source)
                     ->only($keys)
-                    ->filter(fn ($value) => ! blank($value))
-                    ->toArray();
+                    ->notBlank()
+                    ->dot()
+                    ->all();
 
                 $translatedValues = $service->translateAll(
                     $sourceTranslations,
@@ -265,8 +266,9 @@ class Translator
                 $proofreadValues = $service->proofreadAll(
                     texts: $translations
                         ->only($keys)
-                        ->filter(fn ($value) => ! blank($value))
-                        ->toArray()
+                        ->notBlank()
+                        ->dot()
+                        ->all()
                 );
 
                 return $translations->merge($proofreadValues);

--- a/tests/Feature/JsonDriverTest.php
+++ b/tests/Feature/JsonDriverTest.php
@@ -71,7 +71,7 @@ it('gets dead translations', function () {
 
     $dead = $translator->getDeadTranslations('fr');
 
-    expect($dead->keys()->all())->toBe([
+    expect($dead->keys())->toBe([
         'All rights reserved.',
     ]);
 

--- a/tests/Feature/PhpDriverTest.php
+++ b/tests/Feature/PhpDriverTest.php
@@ -40,25 +40,33 @@ it('gets translations', function () {
     $translations = $translator->getTranslations('fr');
 
     expect($translations->toArray())->toBe([
-        'messages.hello' => 'Bonjour',
-        'messages.add' => 'Ajouter',
-        'messages.home.title' => 'Titre',
-        'messages.home.end' => 'Fin',
-        'messages.home.missing' => 'Absent',
-        'messages.empty' => 'Vide',
-        'messages.missing' => 'Absent',
-        'messages.dummy.class' => 'class factice',
-        'messages.dummy.component' => 'composant factice',
-        'messages.dummy.view' => 'vue factice',
-        'messages.dummy.nested.0' => 'used',
-        'messages.dummy.nested.1' => 'as',
-        'messages.dummy.nested.2' => 'array',
-        'messages.register' => 'S\'inscrire',
-        'messages.registered' => 'Inscrit?',
+        'messages' => [
+            'hello' => 'Bonjour',
+            'add' => 'Ajouter',
+            'home' => [
+                'title' => 'Titre',
+                'end' => 'Fin',
+                'missing' => 'Absent',
+            ],
+            'empty' => 'Vide',
+            'missing' => 'Absent',
+            'dummy' => [
+                'class' => 'class factice',
+                'component' => 'composant factice',
+                'view' => 'vue factice',
+                'nested' => [
+                    'used',
+                    'as',
+                    'array',
+                ],
+            ],
+            'register' => 'S\'inscrire',
+            'registered' => 'Inscrit?',
+        ],
     ]);
 });
 
-it('gets undefined translations', function () {
+it('gets missing translations', function () {
     $translator = new Translator(
         driver: $this->getPhpDriver(),
         searchcodeService: $this->getSearchCodeService()
@@ -85,7 +93,7 @@ it('gets dead translations', function () {
 
     $dead = $translator->getDeadTranslations('fr');
 
-    expect($dead->keys()->toArray())->toBe([
+    expect($dead->dot()->keys()->toArray())->toBe([
         'messages.hello',
         'messages.add',
         'messages.home.title',
@@ -99,7 +107,7 @@ it('gets dead translations', function () {
 
 });
 
-it('gets missing translations', function () {
+it('gets untranslated translations', function () {
     $translator = new Translator(
         driver: $this->getPhpDriver(),
         searchcodeService: $this->getSearchCodeService()
@@ -111,10 +119,14 @@ it('gets missing translations', function () {
     );
 
     expect($untranlated->toArray())->toBe([
-        'messages.home.missing' => 'Absent',
-        'messages.empty' => 'Vide',
-        'messages.missing' => 'Absent',
-        'messages.register' => 'S\'inscrire',
+        'messages' => [
+            'home' => [
+                'missing' => 'Absent',
+            ],
+            'empty' => 'Vide',
+            'missing' => 'Absent',
+            'register' => 'S\'inscrire',
+        ],
     ]);
 
 });
@@ -127,7 +139,11 @@ it('replaces dot with unicode', function () {
     $translations = $translator->getTranslations('fr_CA');
 
     expect($translations->toArray())->toBe([
-        'dotted.This key contains a dot&#46; In the middle.And it &#46; ha&#46;s children&#46;' => 'And it has children.',
+        'dotted' => [
+            'This key contains a dot&#46; In the middle' => [
+                'And it &#46; ha&#46;s children&#46;' => 'And it has children.',
+            ],
+        ],
     ]);
 
 });
@@ -142,7 +158,11 @@ it('doesn\'t break keys with dot', function () {
     $translator->saveTranslations('fr_CA', $translations);
 
     expect($translator->getTranslations('fr_CA')->toArray())->toBe([
-        'dotted.This key contains a dot&#46; In the middle.And it &#46; ha&#46;s children&#46;' => 'And it has children.',
+        'dotted' => [
+            'This key contains a dot&#46; In the middle' => [
+                'And it &#46; ha&#46;s children&#46;' => 'And it has children.',
+            ],
+        ],
     ]);
 
 });

--- a/tests/Unit/PhpTranslationsTest.php
+++ b/tests/Unit/PhpTranslationsTest.php
@@ -69,6 +69,93 @@ it('checks existence of translation value', function ($key, $expected) use ($tra
     ['h.i.j.k', true],
 ]);
 
+it('sets a translation value using dot notation', function ($key, $value, $expected) use ($translations) {
+
+    expect($translations->set($key, $value)->toArray())->toBe($expected);
+
+})->with([
+    [
+        '_a',
+        '_a_value',
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'e' => '',
+            'f' => [
+                'g' => '',
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+            '_a' => '_a_value',
+        ],
+    ],
+    [
+        '_a._b._c',
+        '_c_value',
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'e' => '',
+            'f' => [
+                'g' => '',
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+            '_a' => [
+                '_b' => [
+                    '_c' => '_c_value',
+                ],
+            ],
+        ],
+    ],
+    [
+        'a._b',
+        '_b_value',
+        [
+            'a' => [
+                'b' => 'b_value',
+                '_b' => '_b_value',
+
+            ],
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'e' => '',
+            'f' => [
+                'g' => '',
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+        ],
+    ],
+]);
+
 it('filters values', function ($callback, $expected) use ($translations) {
 
     $filtered = $translations->filter($callback);

--- a/tests/Unit/PhpTranslationsTest.php
+++ b/tests/Unit/PhpTranslationsTest.php
@@ -4,31 +4,41 @@ declare(strict_types=1);
 
 use Elegantly\Translator\Collections\PhpTranslations;
 
-it('gets the right translation value', function () {
+$translations = new PhpTranslations([
+    'a' => [
+        'b' => 'b_value',
+    ],
+    'c' => [
+        'd' => ['0_value', '1_value'],
+    ],
+    'e' => '',
+    'f' => [
+        'g' => '',
+    ],
+    'h' => [
+        'i' => [
+            'j' => [
+                'k' => 'k_value',
+                'l' => 'l_value',
+            ],
+        ],
+    ],
+]);
 
-    $translations = new PhpTranslations([
-        'a.b' => 'b_value',
-        'c' => 'c_value',
-        'c.d.0' => '0_value',
-        'c.d.1' => '1_value',
-        'e' => '',
-        'f.g' => '',
-        'h.i.j.k' => 'k_value',
-        'h.i.j.l' => 'l_value',
+it('gets the right translation value', function () use ($translations) {
+
+    expect($translations->get('c'))->toBe([
+        'd' => ['0_value', '1_value'],
     ]);
-
-    expect($translations->get('c'))->toBe('c_value');
     expect($translations->get('a.b'))->toBe('b_value');
     expect($translations->get('a'))->toBe([
         'b' => 'b_value',
     ]);
-    expect($translations->get('c.d'))->toBe([
-        0 => '0_value',
-        1 => '1_value',
-    ]);
+    expect($translations->get('c.d'))->toBe(['0_value', '1_value']);
     expect($translations->get('c.d.1'))->toBe('1_value');
     expect($translations->get('e'))->toBe('');
     expect($translations->get('f.g'))->toBe('');
+    expect($translations->get('h.i.j.l'))->toBe('l_value');
     expect($translations->get('h'))->toBe([
         'i' => [
             'j' => [
@@ -40,50 +50,79 @@ it('gets the right translation value', function () {
 
 });
 
-it('compare two translation keys', function ($a, $b, $expected) {
+it('checks existence of translation value', function ($key, $expected) use ($translations) {
 
-    expect(PhpTranslations::isSubTranslationKey($a, $b))->toBe($expected);
-
-})->with([
-    ['a', 'a', true],
-    ['a', 'b', false],
-    ['a', 'a.b', false],
-    ['a.b', 'a.b', true],
-    ['a.b', 'a', true],
-    ['a.b', 'a.b.c', false],
-    ['a.bcd', 'a.bc', false],
-    ['a.bc', 'a.bc', true],
-    ['a.bc.d', 'a.bc', true],
-    ['a.bc', 'a.bc.d', false],
-]);
-
-it('check existence of translation value', function ($has, $expected) {
-
-    $translations = new PhpTranslations([
-        'a.b' => 'b_value',
-        'c' => 'c_value',
-        'a.bc.d' => 'd_value',
-    ]);
-
-    expect($translations->has($has))->toBe($expected);
+    expect($translations->has($key))->toBe($expected);
 
 })->with([
     ['a', true],
     ['a.b', true],
-    ['c', true],
     ['a.b.c', false],
-    ['a.b.c.d', false],
-    ['e', false],
-    ['a.bcd', false],
-    ['a.bc', true],
-    ['a.bc.d', true],
+    ['c', true],
+    ['c.d.0', true],
+    ['c.d.1', true],
+    ['c.d.2', false],
+    ['e', true],
+    ['f', true],
+    ['f.g', true],
+    ['f.g.h', false],
+    ['h.i.j.k', true],
+]);
+
+it('filters values', function ($callback, $expected) use ($translations) {
+
+    $filtered = $translations->filter($callback);
+
+    expect($filtered->toArray())->toBe($expected);
+
+})->with([
+    [
+        fn ($value, $key) => blank($value),
+        [
+            'e' => '',
+            'f' => [
+                'g' => '',
+            ],
+        ],
+    ],
+    [
+        fn ($value, $key) => ! blank($value),
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+        ],
+    ],
 ]);
 
 it('retreives values except for some translation keys', function ($except, $expected) {
 
     $translations = new PhpTranslations([
-        'a.b' => 'b_value',
-        'c' => 'c_value',
+        'a' => [
+            'b' => 'b_value',
+        ],
+        'c' => [
+            'd' => ['0_value', '1_value'],
+        ],
+        'h' => [
+            'i' => [
+                'j' => [
+                    'k' => 'k_value',
+                    'l' => 'l_value',
+                ],
+            ],
+        ],
     ]);
 
     expect($translations->except($except)->toArray())->toBe($expected);
@@ -91,71 +130,128 @@ it('retreives values except for some translation keys', function ($except, $expe
 })->with([
     [
         ['a'],
-        ['c' => 'c_value'],
+        [
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    [
+        ['c.d.0'],
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+            'c' => [
+                'd' => [1 => '1_value'],
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
+        ],
     ],
     [
         ['a.b'],
-        ['c' => 'c_value'],
-    ],
-    [
-        ['c'],
-        ['a.b' => 'b_value'],
-    ],
-    [
-        ['a.b.c'],
         [
-            'a.b' => 'b_value',
-            'c' => 'c_value',
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                        'l' => 'l_value',
+                    ],
+                ],
+            ],
         ],
+    ],
+    [
+        ['h.i.j.l'],
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+            'c' => [
+                'd' => ['0_value', '1_value'],
+            ],
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    [
+        ['a', 'c.d', 'h.i.j'],
+        [],
     ],
 ]);
 
-it('retreives only the specified translation keys', function ($only, $expected) {
-
-    $translations = new PhpTranslations([
-        'a.b' => 'b_value',
-        'c' => 'c_value',
-    ]);
+it('retreives only the specified translation keys', function ($only, $expected) use ($translations) {
 
     expect($translations->only($only)->toArray())->toBe($expected);
 
 })->with([
     [
         ['a'],
-        ['a.b' => 'b_value'],
+        [
+            'a' => [
+                'b' => 'b_value',
+            ],
+        ],
     ],
     [
-        ['a.b'],
-        ['a.b' => 'b_value'],
-    ],
-    [
-        ['c'],
-        ['c' => 'c_value'],
-    ],
-    [
-        ['a.b.c'],
-        [],
+        ['h.i.j.k'],
+        [
+            'h' => [
+                'i' => [
+                    'j' => [
+                        'k' => 'k_value',
+                    ],
+                ],
+            ],
+        ],
     ],
 ]);
 
 it('encodes dot to unicode', function () {
 
-    $translations = PhpTranslations::toDot([
+    $translations = PhpTranslations::prepareTranslations([
         'This key contains a dot. In the middle' => [
             'And it.has children.' => 'And it has children.',
         ],
     ]);
 
-    expect($translations->toArray())->toBe([
-        'This key contains a dot&#46; In the middle.And it&#46;has children&#46;' => 'And it has children.',
+    expect($translations)->toBe([
+        'This key contains a dot&#46; In the middle' => [
+            'And it&#46;has children&#46;' => 'And it has children.',
+        ],
     ]);
 
 });
 
 it('decodes dot from unicode', function () {
 
-    $translations = PhpTranslations::toUndot([
-        'This key contains a dot&#46; In the middle.And it&#46;has children&#46;' => 'And it has children.',
+    $translations = PhpTranslations::unprepareTranslations([
+        'This key contains a dot&#46; In the middle' => [
+            'And it&#46;has children&#46;' => 'And it has children.',
+        ],
     ]);
 
     expect($translations)->toBe([

--- a/tests/Unit/PhpTranslationsTest.php
+++ b/tests/Unit/PhpTranslationsTest.php
@@ -230,6 +230,82 @@ it('retreives only the specified translation keys', function ($only, $expected) 
     ],
 ]);
 
+it('sorts keys in ascending order', function () {
+
+    $translations = new PhpTranslations([
+        'z' => [
+            'y' => 'y_value',
+            'x' => 'y_value',
+        ],
+        'w' => 'w_value',
+        'a' => [
+            'f' => 'f_value',
+            'b' => [
+                'e' => 'e_value',
+                'c' => 'c_value',
+                'd' => 'd_value',
+            ],
+        ],
+        'v' => 'v_value',
+    ]);
+
+    expect($translations->sortKeys(descending: false)->all())->toBe([
+        'a' => [
+            'b' => [
+                'c' => 'c_value',
+                'd' => 'd_value',
+                'e' => 'e_value',
+            ],
+            'f' => 'f_value',
+        ],
+        'v' => 'v_value',
+        'w' => 'w_value',
+        'z' => [
+            'x' => 'y_value',
+            'y' => 'y_value',
+        ],
+    ]);
+
+});
+
+it('sorts keys in descending order', function () {
+
+    $translations = new PhpTranslations([
+        'z' => [
+            'y' => 'y_value',
+            'x' => 'y_value',
+        ],
+        'w' => 'w_value',
+        'a' => [
+            'f' => 'f_value',
+            'b' => [
+                'e' => 'e_value',
+                'c' => 'c_value',
+                'd' => 'd_value',
+            ],
+        ],
+        'v' => 'v_value',
+    ]);
+
+    expect($translations->sortKeys(descending: true)->all())->toBe([
+        'z' => [
+            'y' => 'y_value',
+            'x' => 'y_value',
+        ],
+        'w' => 'w_value',
+        'v' => 'v_value',
+        'a' => [
+            'f' => 'f_value',
+            'b' => [
+                'e' => 'e_value',
+                'd' => 'd_value',
+                'c' => 'c_value',
+            ],
+        ],
+    ]);
+
+});
+
 it('encodes dot to unicode', function () {
 
     $translations = PhpTranslations::prepareTranslations([


### PR DESCRIPTION
PHP translations are now stored as undotted PHP arrays, resulting in significant performance improvements.